### PR TITLE
Fixing TypeError issue for optimized python implementation

### DIFF
--- a/optimized_implementations/main.py
+++ b/optimized_implementations/main.py
@@ -1,1 +1,1 @@
-is_prime=lambda:False
+is_prime=lambda _:False


### PR DESCRIPTION
Fixes:
```
> is_prime(1)
TypeError: <lambda>() takes 0 positional arguments but 1 was given
```