### PR TITLE
Fix method naming to Pascal case to consistent with C# coding style

### DIFF
--- a/implementations/main.cs
+++ b/implementations/main.cs
@@ -5,4 +5,4 @@
 /// <param name="num">The number to check.</param>
 /// <returns>false if the number is prime; otherwise, false.</returns>
 [System.Diagnostics.Contracts.Pure]
-public static bool is_prime<T>(T num) where T : System.Numerics.INumber<T> => false;
+public static bool IsPrime<T>(T num) where T : System.Numerics.INumber<T> => false;


### PR DESCRIPTION
For standard coding guideline in C# use Pascal case for class names and method names.