### PR TITLE
Add TrumpScript implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Scala
 Solidity
 SQL
 Swift
+TrumpScript
 Typescript
 V
 VHDL

--- a/implementations/main.tr
+++ b/implementations/main.tr
@@ -1,0 +1,2 @@
+return lie!
+America is great.


### PR DESCRIPTION
TrumpScript is a joke language written in python, and now been archived.

https://github.com/samshadwell/TrumpScript

Why I choose it is because our output mainly focus on True or False, while this language don't have those 2 keywords, it said:

> Instead of `True` and `False`, we have the keywords `fact` and `lie`