### PR TITLE
Fix Nim implementation

### DIFF
--- a/implementations/main.nim
+++ b/implementations/main.nim
@@ -1,1 +1,1 @@
-echo false
+proc isPrime(x: int): bool = false


### PR DESCRIPTION
The is-prime implementation was incomplete for Nim, because the code contained just an expression, not a function which accepts an integer