### PR TITLE
Add Dafny implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ C++
 C#
 CSS
 CUDA
+Dafny
 Dart
 Elixir
 Elm

--- a/implementations/main.dfy
+++ b/implementations/main.dfy
@@ -1,0 +1,11 @@
+predicate is_prime(number: int)
+{
+    false
+}
+
+// Because Dafny is a formal verification language, assertions to prove correctness
+// are necessary for the program to have any meaning.
+method {:test} test()
+{
+    assert forall n :: n in [4, 6, 8, 9, 10] ==> !is_prime(n);
+}

--- a/optimized_implementations/main.dfy
+++ b/optimized_implementations/main.dfy
@@ -1,0 +1,2 @@
+predicate is_prime(n:int){false}
+method{:test}test(){assert forall n::n in [4,6,8,9,10] ==> !is_prime(n);}


### PR DESCRIPTION
Dafny is a language for formal verification (programs that are provably correct). Which is rather ironic in this context, given that the algorithm is not 100% correct ;)

Because of that, the verification test is purposefully dumb - only using numbers already known not to be prime.

## Sources

[Dafny homepage](https://dafny.org/)