### PR TITLE
Fix typo in Coffescript implementation

### DIFF
--- a/implementations/main.coffee
+++ b/implementations/main.coffee
@@ -1,1 +1,1 @@
-is_prime = x -> falses
+is_prime = x -> no


### PR DESCRIPTION
It should be `false`, because `falses` is not a valid keyword.

However, Coffescript allows using `no` or `off` as alternatives to `false`, and I think `no` looks funnier. So I changed it to that instead.