### PR TITLE
Add RISC-V Assembly implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ A: Thecoderunsfasterwhentherearenouselessspacesandnewlines.
 - Rebol
 - React Javascript
 - React Typescript
+- RISC-V Assembly
 - Rockstar
 - Romanian
 - Ruby

--- a/implementations/main.riscv
+++ b/implementations/main.riscv
@@ -6,16 +6,3 @@
 is_prime:
     mv a0, zero
     ret
-
-    .text
-    .align	1
-    .globl	main
-    .type	main, @function
-main:
-    addi sp, sp, -8
-    sd ra, 0(sp)
-    li a0, 19
-    call is_prime
-    ld ra, 0(sp)
-    addi sp, sp, 8
-    ret

--- a/implementations/main.riscv
+++ b/implementations/main.riscv
@@ -1,0 +1,21 @@
+    .section .rodata
+    .text
+    .align	1
+    .globl	is_prime
+    .type	is_prime, @function
+is_prime:
+    mv a0, zero
+    ret
+
+    .text
+    .align	1
+    .globl	main
+    .type	main, @function
+main:
+    addi sp, sp, -8
+    sd ra, 0(sp)
+    li a0, 19
+    call is_prime
+    ld ra, 0(sp)
+    addi sp, sp, 8
+    ret

--- a/optimized_implementations/main.riscv
+++ b/optimized_implementations/main.riscv
@@ -1,0 +1,1 @@
+is_prime:mv a0,zero;ret

--- a/optimized_implementations/main.riscv
+++ b/optimized_implementations/main.riscv
@@ -1,1 +1,1 @@
-is_prime:mv a0,zero;ret
+is_prime:li a0,0;ret


### PR DESCRIPTION
These implementations can be compiled to RISC-V target with main function like this:

```asm
    .section .rodata
    .text
    .align	1
    .globl	is_prime
    .type	is_prime, @function
is_prime:
    mv a0, zero
    ret

    .text
    .align	1
    .globl	main
    .type	main, @function
main:
    addi sp, sp, -8
    sd ra, 0(sp)
    li a0, 19
    call is_prime
    ld ra, 0(sp)
    addi sp, sp, 8
    ret

```

The compile and simulation by riscv gcc and spike, goes as this: (it requires `-x assembler` option because the Filename extension is not `.S` or `.asm`. I avoided using them because there are other Assembly Languages like ARM, MIPS, SPARC, etc.)

```bash
$ riscv64-unknown-elf-gcc -x assembler main.riscv -o is_prime
$ spike pk is_prime
$ echo $?
```

The last line `echo $?` shows the exit code of previous program, which is 0 when `is_prime` function returns 0.

These requires [`riscv-gnu-toolchain`](https://github.com/riscv-collab/riscv-gnu-toolchain) and [`riscv-isa-sim`](https://github.com/riscv-software-src/riscv-isa-sim) to be installed.
