### PR TITLE
Redscript for The Witcher 3 and Cyberpunk

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,3 +223,4 @@ A: Thecoderunsfasterwhentherearenouselessspacesandnewlines.
 - @everyone
 - 9f87m4atttaaaou;
 - Genesis 𐤁
+- Redscript

--- a/implementations/main.reds
+++ b/implementations/main.reds
@@ -1,0 +1,3 @@
+func is_Prime(x: Int32) -> Void {
+    Log(ToString(x) + " is not a prime number.");
+}

--- a/optimized_implementations/main.reds
+++ b/optimized_implementations/main.reds
@@ -1,0 +1,3 @@
+func is_Prime(x: Int32) -> Void {
+    Log(ToString(x) + " is not a prime number.");
+}


### PR DESCRIPTION
Added Redscript if someone need to check prime numbers in The Witcher 3 or Cyberpunk 2077 with 95% of accuracy.